### PR TITLE
Allow running custom envs in headless mode, fix packaging setup

### DIFF
--- a/tabular_examples/MANIFEST.in
+++ b/tabular_examples/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include custom_envs/envs/img *
+recursive-include custom_envs/envs/font *
+prune */.ipynb_checkpoints
+prune */.virtual_documents
+global-exclude __pycache__ *.py[cod] .DS_Store

--- a/tabular_examples/custom_envs/envs/frozen_lake.py
+++ b/tabular_examples/custom_envs/envs/frozen_lake.py
@@ -232,11 +232,26 @@ class FrozenLakeEnv(Env):
 
         self.render_mode = render_mode
 
-        self.window_size = (get_monitors()[0].height-50,get_monitors()[0].height-50)
-        self.cell_size = (
-            self.window_size[0] // self.ncol,
-            self.window_size[1] // self.nrow,
+        # Default size works in headless setups.
+        self.cell_size = (64, 64)
+        self.window_size = (
+            self.ncol * self.cell_size[0],
+            self.nrow * self.cell_size[1],
         )
+        # If a monitor is available, keep the larger display-based sizing.
+        if self.render_mode in {"human", "rgb_array"}:
+            try:
+                monitors = get_monitors()
+                if monitors:
+                    window_edge = max(64, monitors[0].height - 50)
+                    self.window_size = (window_edge, window_edge)
+                    self.cell_size = (
+                        max(1, self.window_size[0] // self.ncol),
+                        max(1, self.window_size[1] // self.nrow),
+                    )
+            except Exception:
+                # No display available (e.g., container/CI): keep fallback sizing.
+                pass
         self.window_surface = None
         self.clock = None
         self.hole_img = None

--- a/tabular_examples/custom_envs/envs/recycling_robot.py
+++ b/tabular_examples/custom_envs/envs/recycling_robot.py
@@ -38,14 +38,34 @@ class RecyclingRobotEnv(Env):
                 "You can specify the render_mode at initialization, "
             )
         self.render_type = render_type
-        if self.render_mode != "text" and self.render_type == "node":
-            self.window_size = (get_monitors()[0].height - 200, get_monitors()[0].height - 500)
-            self.cell_size = (self.window_size[0], self.window_size[1])
-            self.render_time = render_time
-        elif self.render_mode != "text" and self.render_type == "robot":
-            self.window_size = (get_monitors()[0].height - 50, get_monitors()[0].height - 50)
-            self.cell_size = (self.window_size[0], self.window_size[1])
-            self.render_time = render_time
+        self.render_time = render_time
+        # Default sizes work in headless setups.
+        if self.render_type == "node":
+            self.window_size = (700, 400)
+        elif self.render_type == "robot":
+            self.window_size = (700, 700)
+        else:
+            self.window_size = (700, 700)
+        self.cell_size = self.window_size
+
+        # If a monitor is available, keep the larger display-based sizing.
+        if self.render_mode in {"human", "rgb_array"}:
+            try:
+                monitors = get_monitors()
+                if monitors:
+                    monitor_height = monitors[0].height
+                    if self.render_type == "node":
+                        self.window_size = (
+                            max(64, monitor_height - 200),
+                            max(64, monitor_height - 500),
+                        )
+                    elif self.render_type == "robot":
+                        window_edge = max(64, monitor_height - 50)
+                        self.window_size = (window_edge, window_edge)
+                    self.cell_size = self.window_size
+            except Exception:
+                # No display available (e.g., container/CI): keep fallback sizing.
+                pass
         self.window_surface = None
         self.rb_broken = None
         self.rb_high = None

--- a/tabular_examples/setup.py
+++ b/tabular_examples/setup.py
@@ -1,11 +1,13 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
-    name='custom_envs',
-    version='0.0.1',
-    packages=['custom_envs'],
-    install_requires=['gymnasium'],
-    description='Custom Environments for Reinforcement Learning',
-    author='Bernd Frauenknecht, Emma Cramer, Ramil Sabirov, Lukas Kesper',
-    options={'clean': {'all': True}}
+    name="custom_envs",
+    version="0.0.1",
+    packages=find_packages(include=["custom_envs", "custom_envs.*"]),
+    include_package_data=True,
+    package_data={"custom_envs": ["envs/img/*", "envs/font/*"]},
+    install_requires=["gymnasium"],
+    description="Custom Environments for Reinforcement Learning",
+    author="Bernd Frauenknecht, Emma Cramer, Ramil Sabirov, Lukas Kesper",
+    options={"clean": {"all": True}},
 )


### PR DESCRIPTION
Required for grading bonus point assignments in containers on machines without a screen.

Packaging update fixes issue where `custom_envs.envs` was not recognized as a package when installed in pixi environments thruogh `custom-envs = { git = "https://github.com/Data-Science-in-Mechanical-Engineering/RLLBC.git", rev = "commit-id", subdirectory = "tabular_examples" }`.